### PR TITLE
Resolved incompatibilities with VS2017 of 0.10.1

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -60,22 +60,18 @@ void client::doGui()
     ImGui::SameLine();
     ImGui::TextColored(ImVec4(0.5f,0.3f,1.0f,1.0f), "%d", port);
 	
-	//char* rigidstr = new char[6 + ip.length() + 6];
     sprintf(rigidstr, "Rigid##%s%i", ip.c_str(), port);
     ImGui::Checkbox(rigidstr, &isRigid);
     ImGui::SameLine();
 	
-	//char* markstr = new char[6+ip.length()+6];
     sprintf(markstr, "Mark##%s%i", ip.c_str(), port);
     ImGui::Checkbox(markstr, &isMarker);
     ImGui::SameLine();
 	
-	//char* skelstr = new char[6+ip.length()+6];
     sprintf(skelstr, "Skel##%s%i", ip.c_str(), port);
     ImGui::Checkbox(skelstr, &isSkeleton);
     ImGui::SameLine();
-	
-	//char* hierstr = new char[6+ip.length()+6];
+
     sprintf(hierstr, "Hierarchy##%s%i", ip.c_str(), port);
     ImGui::Checkbox(hierstr, &deepHierarchy);
     

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -23,6 +23,11 @@ client::client(int ind,string i,int p,string n,bool r,bool m,bool s, bool live, 
     deepHierarchy = hier;
     mode = cMode;
     setupSender();
+
+	rigidstr = new char[6 + ip.length() + 6];
+	markstr = new char[6 + ip.length() + 6];
+	skelstr = new char[6 + ip.length() + 6];
+	hierstr = new char[6 + ip.length() + 6];
 }
 
 client::~client(){}
@@ -54,19 +59,23 @@ void client::doGui()
     ImGui::Text("port:");
     ImGui::SameLine();
     ImGui::TextColored(ImVec4(0.5f,0.3f,1.0f,1.0f), "%d", port);
-    char rigidstr[6+ip.length()+6];
+	
+	//char* rigidstr = new char[6 + ip.length() + 6];
     sprintf(rigidstr, "Rigid##%s%i", ip.c_str(), port);
     ImGui::Checkbox(rigidstr, &isRigid);
     ImGui::SameLine();
-    char markstr[6+ip.length()+6];
+	
+	//char* markstr = new char[6+ip.length()+6];
     sprintf(markstr, "Mark##%s%i", ip.c_str(), port);
     ImGui::Checkbox(markstr, &isMarker);
     ImGui::SameLine();
-    char skelstr[6+ip.length()+6];
+	
+	//char* skelstr = new char[6+ip.length()+6];
     sprintf(skelstr, "Skel##%s%i", ip.c_str(), port);
     ImGui::Checkbox(skelstr, &isSkeleton);
     ImGui::SameLine();
-    char hierstr[6+ip.length()+6];
+	
+	//char* hierstr = new char[6+ip.length()+6];
     sprintf(hierstr, "Hierarchy##%s%i", ip.c_str(), port);
     ImGui::Checkbox(hierstr, &deepHierarchy);
     

--- a/src/client.h
+++ b/src/client.h
@@ -71,7 +71,11 @@ private:
     bool            deepHierarchy;
     ClientMode      mode;
     ofxOscSender    sender;
-    
+
+	char*			rigidstr;
+	char*			markstr;
+	char*			skelstr;
+	char*			hierstr;
 };
 
 #endif /* defined(__NatNet2OSCbridge__client__) */

--- a/src/ect_helpers.cpp
+++ b/src/ect_helpers.cpp
@@ -1,7 +1,7 @@
 #include "ofFileUtils.h"
 #include "ofUtils.h"
 #include "ofLog.h"
-#include "helpers.h"
+#include "ect_helpers.h"
 
 std::string getAppConfigDir()
 {

--- a/src/ect_helpers.h
+++ b/src/ect_helpers.h
@@ -1,5 +1,5 @@
-#ifndef HELPERS_H
-#define HELPERS_H
+#ifndef ECT_HELPERS_H
+#define ECT_HELPERS_H
 
 #pragma once
 
@@ -48,4 +48,4 @@ bool Combo(const char* label, int* currIndex, std::vector<std::string>& values);
 bool ListBox(const char* label, int* currIndex, std::vector<std::string>& values);
 }
 
-#endif // HELPERS_H
+#endif // ECT_HELPERS_H

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -2,7 +2,7 @@
 #include "fontawesome5.h"
 #include "version.h"
 #include "themes.h"
-#include "helpers.h"
+#include "ect_helpers.h"
 
 static const ImWchar icon_ranges[] = { ICON_MIN_FA, ICON_MAX_FA, 0 };
 


### PR DESCRIPTION
Since Windows NTFS is case insensitive, VS2017 was generating unresolved symbols for everything in our "helpers.h" since it conflicted with ofxImGui's "Helpers.h"

I renamed ours to ect_helpers.h for now.

There was also a compilation issue with how the char[]'s in client::doGui were being declared, so I moved them to a member char*, and created them during client construction using new. This circumvented the "'this' cannot be used in a constant expression" error I was getting in VS2017.