### PR TITLE
Added save/load of setup xml feature.

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -24,10 +24,10 @@ client::client(int ind,string i,int p,string n,bool r,bool m,bool s, bool live, 
     mode = cMode;
     setupSender();
 
-	rigidstr = new char[6 + ip.length() + 6];
-	markstr = new char[6 + ip.length() + 6];
-	skelstr = new char[6 + ip.length() + 6];
-	hierstr = new char[6 + ip.length() + 6];
+    rigidstr = new char[6 + ip.length() + 6];
+    markstr = new char[6 + ip.length() + 6];
+    skelstr = new char[6 + ip.length() + 6];
+    hierstr = new char[6 + ip.length() + 6];
 }
 
 client::~client(){}
@@ -59,15 +59,15 @@ void client::doGui()
     ImGui::Text("port:");
     ImGui::SameLine();
     ImGui::TextColored(ImVec4(0.5f,0.3f,1.0f,1.0f), "%d", port);
-	
+    
     sprintf(rigidstr, "Rigid##%s%i", ip.c_str(), port);
     ImGui::Checkbox(rigidstr, &isRigid);
     ImGui::SameLine();
-	
+    
     sprintf(markstr, "Mark##%s%i", ip.c_str(), port);
     ImGui::Checkbox(markstr, &isMarker);
     ImGui::SameLine();
-	
+    
     sprintf(skelstr, "Skel##%s%i", ip.c_str(), port);
     ImGui::Checkbox(skelstr, &isSkeleton);
     ImGui::SameLine();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -60,22 +60,18 @@ void client::doGui()
     ImGui::SameLine();
     ImGui::TextColored(ImVec4(0.5f,0.3f,1.0f,1.0f), "%d", port);
 	
-	//char* rigidstr = new char[6 + ip.length() + 6];
     sprintf(rigidstr, "Rigid##%s%i", ip.c_str(), port);
     ImGui::Checkbox(rigidstr, &isRigid);
     ImGui::SameLine();
 	
-	//char* markstr = new char[6+ip.length()+6];
     sprintf(markstr, "Mark##%s%i", ip.c_str(), port);
     ImGui::Checkbox(markstr, &isMarker);
     ImGui::SameLine();
 	
-	//char* skelstr = new char[6+ip.length()+6];
     sprintf(skelstr, "Skel##%s%i", ip.c_str(), port);
     ImGui::Checkbox(skelstr, &isSkeleton);
     ImGui::SameLine();
-	
-	//char* hierstr = new char[6+ip.length()+6];
+
     sprintf(hierstr, "Hierarchy##%s%i", ip.c_str(), port);
     ImGui::Checkbox(hierstr, &deepHierarchy);
     

--- a/src/client.h
+++ b/src/client.h
@@ -72,10 +72,10 @@ private:
     ClientMode      mode;
     ofxOscSender    sender;
 
-	char*			rigidstr;
-	char*			markstr;
-	char*			skelstr;
-	char*			hierstr;
+    char*            rigidstr;
+    char*            markstr;
+    char*            skelstr;
+    char*            hierstr;
 };
 
 #endif /* defined(__NatNet2OSCbridge__client__) */

--- a/src/ect_helpers.cpp
+++ b/src/ect_helpers.cpp
@@ -15,7 +15,7 @@ std::string getAppConfigDir()
     return dir;
 #elif defined(TARGET_WINDOWS) || defined(TARGET_WIN32)
     std::string appdata = ofGetEnv( "APPDATA" );
-    std::string dir = ofFilePath::join( appdata,  "/NatNet2OSC_bridge" );
+    std::string dir = ofFilePath::join( appdata,  "\\NatNet2OSC_bridge" );
     if ( ! ofDirectory::createDirectory( dir, false, true ) )
     {
         ofLogNotice() << "couldn't create or open " << dir << "reverting to bin/data";

--- a/src/ect_helpers.cpp
+++ b/src/ect_helpers.cpp
@@ -30,11 +30,11 @@ std::string getAppConfigDir()
 void browseAppConfigDir()
 {
 #if defined(TARGET_LINUX)
-	ofLogVerbose("Not yet implemented");
+    ofLogVerbose("Not yet implemented");
 #elif defined(TARGET_OSX)
-	ofSystem("open " + getAppConfigDir());
+    ofSystem("open " + getAppConfigDir());
 #elif defined(TARGET_WINDOWS) || defined(TARGET_WIN32)
-	ofSystem("explorer " + getAppConfigDir());
+    ofSystem("explorer " + getAppConfigDir());
 #endif
 }
 

--- a/src/ect_helpers.h
+++ b/src/ect_helpers.h
@@ -13,7 +13,7 @@
 // return the path to where the user can save application data
 std::string getAppConfigDir();
 // opens a file browser to the app config dir (so people can find their setups)
-void		browseAppConfigDir();
+void        browseAppConfigDir();
 
 /// \brief A typedef for Poco::Net::NetworkInterface.
 typedef Poco::Net::NetworkInterface NetworkInterface;

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -40,7 +40,9 @@ void ofApp::setup()
     current_iface_idx = iface_list.size() - 1;
     setupConnectionInterface();
 
-	save_fileName = new char[32]{ "setup.xml" };
+	string initialXml = "setup.xml";
+	save_fileName = new char[32];
+	strcpy(save_fileName, initialXml.c_str());
 
     setupData("");
     visible = true;

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -795,7 +795,7 @@ void ofApp::doGui() {
 				setupData(save_fileName);
 			}
 			ImGui::SameLine();
-			if (ImGui::Button(ICON_FA_FILE_DOWNLOAD " Open Folder"))
+			if (ImGui::Button(ICON_FA_FOLDER_OPEN " Open Folder"))
 			{
 				browseAppConfigDir();
 			}

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -39,7 +39,10 @@ void ofApp::setup()
     // and set the current iface to last found (first is probably lo)
     current_iface_idx = iface_list.size() - 1;
     setupConnectionInterface();
-    setupData();
+
+	save_fileName = new char[32]{ "setup.xml" };
+
+    setupData("");
     visible = true;
     numRigidBody = 0;
     numSkeleton = 0;
@@ -79,16 +82,37 @@ void ofApp::setupConnectionInterface(){
     
 }
 
-void ofApp::setupData()
+void ofApp::setupData( string filename="" )
 {
 	ofLogVerbose("SetupData:: connection");
     userDataDir = getAppConfigDir();
-    string xmlpath = ofFilePath::join(userDataDir, "setup.xml");
-    if ( ! ofFile::doesFileExist( xmlpath ) )
+	string xmlpath = ofFilePath::join(userDataDir, save_fileName); //setup.xml );
+	string persistentPath = ofFilePath::join(userDataDir, "persistent_state.xml");
+    if ( filename == "" || !ofFile::doesFileExist( xmlpath ) )
     {
-        xmlpath = "setup.xml";
-        ofLogVerbose() << "Loading setup from packaged " << xmlpath << " probably first run or never saved on this system?";
+		if (!ofFile::doesFileExist(persistentPath)) {
+			xmlpath = "setup.xml";
+			ofLogVerbose() << "Loading setup from packaged " << xmlpath << " probably first run or never saved on this system?";
+		}
+		else {
+			ofxXmlSettings state(persistentPath);
+			state.pushTag("name");
+			xmlpath = state.getValue("filename", "setup.xml");
+			strcpy(save_fileName, xmlpath.c_str());
+			xmlpath = ofFilePath::join(userDataDir, xmlpath);
+			state.popTag();
+		}
     }
+	else if ( filename != "" ) {	//"" = load from initial setup
+		//store name of last loaded file
+		ofxXmlSettings persistent_state;
+		persistent_state.addTag("name");
+		persistent_state.pushTag("name", 0);
+		persistent_state.addValue("filename", save_fileName);
+		persistent_state.popTag();
+		persistent_state.save(persistentPath);
+	}
+
     ofxXmlSettings data( xmlpath );
     data.pushTag("setup",0);
     FPS = data.getValue("fps", 30);
@@ -115,9 +139,15 @@ void ofApp::setupData()
     ofSetFrameRate(FPS);
     data.popTag();
 
-	ofLogVerbose("SetupData:: clients");
+
+	while( clients.size() > 0 ) {
+		int i = 0;
+		deleteClient(i);
+	}
 
     int numClients = data.getNumTags("client");
+
+	ofLogVerbose("SetupData:: clients (" + ofToString(numClients) + ")");
     for (int i = 0; i < numClients; i++)
     {
         data.pushTag("client",i);
@@ -614,7 +644,7 @@ void ofApp::dragEvent(ofDragInfo dragInfo){
 void ofApp::saveData(string filepath="")
 {
     if ( filepath == "" ) {
-        filepath = ofFilePath::join( userDataDir, "setup.xml");
+		filepath = ofFilePath::join(userDataDir, save_fileName);// "setup.xml");
     }
     ofLogNotice("Starting save data to " + filepath);
     ofxXmlSettings save;
@@ -640,6 +670,16 @@ void ofApp::saveData(string filepath="")
         save.popTag();
     }
     save.save(filepath);
+
+	//store name of last saved file
+	string persistentPath = ofFilePath::join(userDataDir, "persistent_state.xml");
+	ofxXmlSettings persistent_state;
+	persistent_state.addTag("name");
+	persistent_state.pushTag("name", 0);
+	persistent_state.addValue("filename", save_fileName);
+	persistent_state.popTag();
+	persistent_state.save(persistentPath);
+
     ofLogNotice("fps "+ofToString(FPS)+" interface " + iface_list.at(current_iface_idx) +" ip "+ofToString(natnetip_char));
     ofLogNotice("Save Data Finished");
 }
@@ -742,10 +782,16 @@ void ofApp::doGui() {
             ImGui::Spacing();
 
 
+			ImGui::InputText("file name", save_fileName, 32);
             if ( ImGui::Button(ICON_FA_SAVE " Save Setup") )
             {
                 saveData();
             }
+			ImGui::SameLine();
+			if (ImGui::Button(ICON_FA_FILE_DOWNLOAD " Load Setup"))
+			{
+				setupData(save_fileName);
+			}
 
             ImGui::Spacing();
             ImGui::Separator();

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -40,9 +40,9 @@ void ofApp::setup()
     current_iface_idx = iface_list.size() - 1;
     setupConnectionInterface();
 
-	string initialXml = "setup.xml";
-	save_fileName = new char[32];
-	strcpy(save_fileName, initialXml.c_str());
+    string initialXml = "setup.xml";
+    save_fileName = new char[32];
+    strcpy(save_fileName, initialXml.c_str());
 
     setupData("");
     visible = true;
@@ -86,34 +86,34 @@ void ofApp::setupConnectionInterface(){
 
 void ofApp::setupData( string filename="" )
 {
-	ofLogVerbose("SetupData:: connection");
+    ofLogVerbose("SetupData:: connection");
     userDataDir = getAppConfigDir();
-	string xmlpath = ofFilePath::join(userDataDir, save_fileName); //setup.xml );
-	string persistentPath = ofFilePath::join(userDataDir, "persistent_state.xml");
+    string xmlpath = ofFilePath::join(userDataDir, save_fileName); //setup.xml );
+    string persistentPath = ofFilePath::join(userDataDir, "persistent_state.xml");
     if ( filename == "" || !ofFile::doesFileExist( xmlpath ) )
     {
-		if (!ofFile::doesFileExist(persistentPath)) {
-			xmlpath = "setup.xml";
-			ofLogVerbose() << "Loading setup from packaged " << xmlpath << " probably first run or never saved on this system?";
-		}
-		else {
-			ofxXmlSettings state(persistentPath);
-			state.pushTag("name");
-			xmlpath = state.getValue("filename", "setup.xml");
-			strcpy(save_fileName, xmlpath.c_str());
-			xmlpath = ofFilePath::join(userDataDir, xmlpath);
-			state.popTag();
-		}
+        if (!ofFile::doesFileExist(persistentPath)) {
+            xmlpath = "setup.xml";
+            ofLogVerbose() << "Loading setup from packaged " << xmlpath << " probably first run or never saved on this system?";
+        }
+        else {
+            ofxXmlSettings state(persistentPath);
+            state.pushTag("name");
+            xmlpath = state.getValue("filename", "setup.xml");
+            strcpy(save_fileName, xmlpath.c_str());
+            xmlpath = ofFilePath::join(userDataDir, xmlpath);
+            state.popTag();
+        }
     }
-	else if ( filename != "" ) {	//"" = load from initial setup
-		//store name of last loaded file
-		ofxXmlSettings persistent_state;
-		persistent_state.addTag("name");
-		persistent_state.pushTag("name", 0);
-		persistent_state.addValue("filename", save_fileName);
-		persistent_state.popTag();
-		persistent_state.save(persistentPath);
-	}
+    else if ( filename != "" ) {    //"" = load from initial setup
+        //store name of last loaded file
+        ofxXmlSettings persistent_state;
+        persistent_state.addTag("name");
+        persistent_state.pushTag("name", 0);
+        persistent_state.addValue("filename", save_fileName);
+        persistent_state.popTag();
+        persistent_state.save(persistentPath);
+    }
 
     ofxXmlSettings data( xmlpath );
     data.pushTag("setup",0);
@@ -142,14 +142,14 @@ void ofApp::setupData( string filename="" )
     data.popTag();
 
 
-	while( clients.size() > 0 ) {
-		int i = 0;
-		deleteClient(i);
-	}
+    while( clients.size() > 0 ) {
+        int i = 0;
+        deleteClient(i);
+    }
 
     int numClients = data.getNumTags("client");
 
-	ofLogVerbose("SetupData:: clients (" + ofToString(numClients) + ")");
+    ofLogVerbose("SetupData:: clients (" + ofToString(numClients) + ")");
     for (int i = 0; i < numClients; i++)
     {
         data.pushTag("client",i);
@@ -166,7 +166,7 @@ void ofApp::setupData( string filename="" )
         data.popTag();
     }
 
-	ofLogVerbose("SetupData :: DONE");
+    ofLogVerbose("SetupData :: DONE");
 }
 
 
@@ -177,7 +177,7 @@ bool ofApp::connectNatnet(string interfaceName, string interfaceIP)
     natnet.setup(interfaceName, interfaceIP);  // interface name, server ip
     //natnet.setDuplicatedPointRemovalDistance(20);
     
-	return false;
+    return false;
 }
 
 
@@ -646,7 +646,7 @@ void ofApp::dragEvent(ofDragInfo dragInfo){
 void ofApp::saveData(string filepath="")
 {
     if ( filepath == "" ) {
-		filepath = ofFilePath::join(userDataDir, save_fileName);// "setup.xml");
+        filepath = ofFilePath::join(userDataDir, save_fileName);// "setup.xml");
     }
     ofLogNotice("Starting save data to " + filepath);
     ofxXmlSettings save;
@@ -673,14 +673,14 @@ void ofApp::saveData(string filepath="")
     }
     save.save(filepath);
 
-	//store name of last saved file
-	string persistentPath = ofFilePath::join(userDataDir, "persistent_state.xml");
-	ofxXmlSettings persistent_state;
-	persistent_state.addTag("name");
-	persistent_state.pushTag("name", 0);
-	persistent_state.addValue("filename", save_fileName);
-	persistent_state.popTag();
-	persistent_state.save(persistentPath);
+    //store name of last saved file
+    string persistentPath = ofFilePath::join(userDataDir, "persistent_state.xml");
+    ofxXmlSettings persistent_state;
+    persistent_state.addTag("name");
+    persistent_state.pushTag("name", 0);
+    persistent_state.addValue("filename", save_fileName);
+    persistent_state.popTag();
+    persistent_state.save(persistentPath);
 
     ofLogNotice("fps "+ofToString(FPS)+" interface " + iface_list.at(current_iface_idx) +" ip "+ofToString(natnetip_char));
     ofLogNotice("Save Data Finished");
@@ -784,21 +784,21 @@ void ofApp::doGui() {
             ImGui::Spacing();
 
 
-			ImGui::InputText("file name", save_fileName, 32);
+            ImGui::InputText("file name", save_fileName, 32);
             if ( ImGui::Button(ICON_FA_SAVE " Save Setup") )
             {
                 saveData();
             }
-			ImGui::SameLine();
-			if (ImGui::Button(ICON_FA_FILE_DOWNLOAD " Load Setup"))
-			{
-				setupData(save_fileName);
-			}
-			ImGui::SameLine();
-			if (ImGui::Button(ICON_FA_FOLDER_OPEN " Open Folder"))
-			{
-				browseAppConfigDir();
-			}
+            ImGui::SameLine();
+            if (ImGui::Button(ICON_FA_FILE_DOWNLOAD " Load Setup"))
+            {
+                setupData(save_fileName);
+            }
+            ImGui::SameLine();
+            if (ImGui::Button(ICON_FA_FOLDER_OPEN " Open Folder"))
+            {
+                browseAppConfigDir();
+            }
 
             ImGui::Spacing();
             ImGui::Separator();

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -44,7 +44,7 @@ public:
     void gotMessage(ofMessage msg);
     
     void setupConnectionInterface();
-    void setupData();
+    void setupData(string filename);
     void addClient(int i,string ip,int p,string n,bool r,bool m,bool s,bool live, bool hierarchy, ClientMode mode);
     void sendOSC();
     
@@ -104,6 +104,7 @@ private:
     float               invFPS;
     int                 FPS;
     char                natnetip_char[16];
+	char*				save_fileName;
     int                 current_iface_idx;
     vector<string>      iface_list;
 };

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -104,7 +104,7 @@ private:
     float               invFPS;
     int                 FPS;
     char                natnetip_char[16];
-	char*				save_fileName;
+    char*                save_fileName;
     int                 current_iface_idx;
     vector<string>      iface_list;
 };


### PR DESCRIPTION
Saves to roaming storage (tested to function properly on Windows 10), and also stores a persistent_state.xml that currently only includes the last file that was loaded or saved (we could use that at a later time to restore application state between runs).

resolves #3 