### PR TITLE
app bundles (OSX) have unpredictable working dirs, workaround this

### DIFF
--- a/src/ofpy.cpp
+++ b/src/ofpy.cpp
@@ -1,5 +1,11 @@
 #include "ofpy.h"
 #include "ofLog.h"
+#ifdef TARGET_OSX
+#include <unistd.h>      // for chdir
+#include <libgen.h>      // for dirname
+#include <mach-o/dyld.h> // for _NSGetExecutablePath
+#include <limits.h>      // for PATH_MAX?
+#endif
 
 /*extern "C"{
 PyObject* PyInit__openframeworks(void);
@@ -9,6 +15,16 @@ PyObject* PyInit__glm(void);
 int init_python()
 {
 #ifdef TARGET_OSX
+    char path[PATH_MAX];
+    uint32_t pathLen = sizeof(path);
+    int err = _NSGetExecutablePath(path, &pathLen);
+    assert(!err);
+
+    // Switch to the directory of the actual binary
+    chdir(dirname(path));
+    // and then go up three directories to get to the folder of the .app bundle
+    //chdir("../../../");
+
     Py_SetProgramName(L"../../../python/bin/python");     // L prepend is string literal (ddg it)
     Py_SetPythonHome(L"../../../python");
     Py_Initialize();


### PR DESCRIPTION
added code to set the working dir based on the executable path