### PR TITLE
add support for sending Midi data

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,6 +49,7 @@ install:
 - cd addons
 - git clone --depth=1 https://github.com/jvcleave/ofxImGui.git
 - git clone --depth=1 https://github.com/hku-ect/ofxNatNet.git
+- git clone --depth=1 https://github.com/danomatika/ofxMidi.git
 - cd ..\apps\myapps\%APPVEYOR_PROJECT_NAME%
 
 build_script:

--- a/addons.make
+++ b/addons.make
@@ -3,3 +3,4 @@ ofxNatNet
 ofxOsc
 ofxPoco
 ofxXmlSettings
+ofxMidi

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -136,6 +136,16 @@ void client::doGui()
             ImGui::EndTooltip();
         }
     }
+    ImGui::SameLine();
+    ImGui::Checkbox("Midi", &recvMidi);
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+        ImGui::TextUnformatted("Send midi data");
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
 
     ImGui::PopID();
 

--- a/src/client.h
+++ b/src/client.h
@@ -49,6 +49,7 @@ public:
     bool &getSkeleton();
     bool &getLive();
     bool &getHierarchy();
+    bool &getMidiFlag() { return recvMidi; }
     int &getModeFlags();
 
     ofEvent<int> deleteClient;
@@ -63,6 +64,7 @@ private:
     bool            isSkeleton;
     bool            isLive;
     bool            deepHierarchy;
+    bool            recvMidi;
     int             modeFlags;
     ofxOscSender    sender;
 

--- a/src/midinode.h
+++ b/src/midinode.h
@@ -1,0 +1,58 @@
+#ifndef MIDINODE_H
+#define MIDINODE_H
+#include "ofMain.h"
+#include "ofxMidi.h"
+
+class midiNode : public ofxMidiListener
+{
+public:
+    midiNode()
+    {
+        midiIn.listInPorts();
+        midiIn.ignoreTypes(false, false, false);
+        midiIn.addListener(this);
+        refreshDevices();
+    }
+
+    virtual ~midiNode()
+    {
+        midiIn.closePort();
+        midiIn.removeListener(this);
+    }
+
+    void newMidiMessage(ofxMidiMessage& msg)
+    {
+        lock.lock(); //  see https://github.com/danomatika/ofxMidi/issues/76
+        midiMessages.push_back(msg);
+        // remove any old messages if we have too many
+        while(midiMessages.size() > maxMessages) {
+            midiMessages.erase(midiMessages.begin());
+        }
+        lock.unlock();
+    }
+
+    void refreshDevices() {
+        ofLogNotice("ofxMidiIn") << midiIn.getNumInPorts() << " ports available";
+        midiDevices.clear();
+        midiDevices = midiIn.getInPortList();
+        midiDevices.insert(midiDevices.begin(), "none");
+    }
+
+    void doGui()
+    {
+
+    }
+
+    ofxMidiIn midiIn;
+    std::vector<ofxMidiMessage> midiMessages;
+    std::vector<string> midiDevices;
+    int currentDevice = 0;
+    std::size_t maxMessages = 100; //< max number of messages to keep track of
+    ofMutex lock;
+    bool verbose = false;
+    bool ignoreSysex= false;
+    bool ignoreTiming = false;
+    bool ignoreSense = false;
+};
+
+#endif // MIDINODE_H

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -8,6 +8,7 @@
 #include "ofxImGui.h"
 #include "uiWidgets.h"
 #include "ofpy.h"
+#include "midinode.h"
 
 //for velocity, defines how many layers to apply (2 * layers + 1 frames)
 #define SMOOTHING 0
@@ -48,14 +49,17 @@ public:
     void setupData(string filename);
     void addClient(int i,string ip,int p,string n,bool r,bool m,bool s,bool live, bool hierarchy, int modeFlags);
     void sendOSC();
-    
+    void sendMidi();
+
     bool connectNatnet(string interfaceName, string interfaceIP);
     
     void saveData(string filepath);
     void deleteClient(int &index);
     
     void setFeedback(string feedbackText);
-    
+
+    midiNode midiIn;
+
     //GUI
     ofxImGui::Gui gui;
     bool guiVisible;
@@ -67,6 +71,7 @@ public:
     uiLogger uiLogWidget;
     
 private:
+
     void                    sendAllMarkers();
     void                    sendAllRigidBodys();
     void                    sendAllSkeletons();


### PR DESCRIPTION
Users can select a midi device and flag clients which need to receive the midi data received.