### PR TITLE
Add Midi and OSC reveive support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,6 +49,7 @@ install:
 - cd addons
 - git clone --depth=1 https://github.com/jvcleave/ofxImGui.git
 - git clone --depth=1 https://github.com/hku-ect/ofxNatNet.git
+- git clone --depth=1 https://github.com/danomatika/ofxMidi.git
 - cd ..\apps\myapps\%APPVEYOR_PROJECT_NAME%
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,7 @@ install:
 - if "%BUILDER%"=="MSYS2" %MSYS2_PATH%\usr\bin\bash -lc "scripts/msys2/install_dependencies.sh --noconfirm"
 - if "%BUILDER%"=="MSYS2" %MSYS2_PATH%\usr\bin\bash -lc "scripts/msys2/download_libs.sh --silent"
 - cd addons
-- git clone --depth=1 https://github.com/jvcleave/ofxImGui.git
+- git clone --depth=1 --branch=173stdlib https://github.com/sphaero/ofxImGui.git
 - git clone --depth=1 https://github.com/hku-ect/ofxNatNet.git
 - git clone --depth=1 https://github.com/danomatika/ofxMidi.git
 - cd ..\apps\myapps\%APPVEYOR_PROJECT_NAME%

--- a/addons.make
+++ b/addons.make
@@ -3,3 +3,4 @@ ofxNatNet
 ofxOsc
 ofxPoco
 ofxXmlSettings
+ofxMidi

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -136,6 +136,16 @@ void client::doGui()
             ImGui::EndTooltip();
         }
     }
+    ImGui::SameLine();
+    ImGui::Checkbox("Midi", &recvMidi);
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+        ImGui::TextUnformatted("Send midi data");
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
 
     ImGui::PopID();
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -10,7 +10,7 @@
 #include "fontawesome5.h"
 #include "ect_helpers.h"
 
-client::client(int ind,string i,int p,string n,bool r,bool m,bool s, bool live, bool hier, int mFlags )
+client::client(int ind,string i,int p,string n,bool r,bool m,bool s, bool live, bool hier, int mFlags, bool midi, bool osc )
 {
     //arange them gridwise
     index = ind;
@@ -143,6 +143,16 @@ void client::doGui()
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
         ImGui::TextUnformatted("Send midi data");
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
+    ImGui::SameLine();
+    ImGui::Checkbox("OSC", &recvOSC);
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+        ImGui::TextUnformatted("Send received OSC data");
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }

--- a/src/client.h
+++ b/src/client.h
@@ -49,6 +49,7 @@ public:
     bool &getSkeleton();
     bool &getLive();
     bool &getHierarchy();
+    bool &getMidiFlag() { return recvMidi; }
     int &getModeFlags();
 
     ofEvent<int> deleteClient;
@@ -63,6 +64,7 @@ private:
     bool            isSkeleton;
     bool            isLive;
     bool            deepHierarchy;
+    bool            recvMidi;
     int             modeFlags;
     ofxOscSender    sender;
 

--- a/src/client.h
+++ b/src/client.h
@@ -28,7 +28,7 @@ enum ClientFlags
 class client
 {
 public:
-    client(int ind,string i,int p,string n,bool r,bool m,bool s, bool live, bool hier, int modeFlags);
+    client(int ind,string i,int p,string n,bool r,bool m,bool s, bool live, bool hier, int modeFlags, bool midi, bool osc);
     ~client();
     
     void setupSender();
@@ -50,6 +50,7 @@ public:
     bool &getLive();
     bool &getHierarchy();
     bool &getMidiFlag() { return recvMidi; }
+    bool &getOSCFlag() { return recvOSC; }
     int &getModeFlags();
 
     ofEvent<int> deleteClient;
@@ -64,7 +65,8 @@ private:
     bool            isSkeleton;
     bool            isLive;
     bool            deepHierarchy;
-    bool            recvMidi;
+    bool            recvMidi = false;
+    bool            recvOSC = false;
     int             modeFlags;
     ofxOscSender    sender;
 

--- a/src/midinode.h
+++ b/src/midinode.h
@@ -47,8 +47,10 @@ public:
     std::vector<ofxMidiMessage> midiMessages;
     std::vector<string> midiDevices;
     int currentDevice = 0;
+    string currentDeviceName= "";
     std::size_t maxMessages = 100; //< max number of messages to keep track of
     ofMutex lock;
+    bool sendRaw = false;
     bool verbose = false;
     bool ignoreSysex= false;
     bool ignoreTiming = false;

--- a/src/midinode.h
+++ b/src/midinode.h
@@ -1,0 +1,58 @@
+#ifndef MIDINODE_H
+#define MIDINODE_H
+#include "ofMain.h"
+#include "ofxMidi.h"
+
+class midiNode : public ofxMidiListener
+{
+public:
+    midiNode()
+    {
+        midiIn.listInPorts();
+        midiIn.ignoreTypes(false, false, false);
+        midiIn.addListener(this);
+        refreshDevices();
+    }
+
+    virtual ~midiNode()
+    {
+        midiIn.closePort();
+        midiIn.removeListener(this);
+    }
+
+    void newMidiMessage(ofxMidiMessage& msg)
+    {
+        lock.lock(); //  see https://github.com/danomatika/ofxMidi/issues/76
+        midiMessages.push_back(msg);
+        // remove any old messages if we have too many
+        while(midiMessages.size() > maxMessages) {
+            midiMessages.erase(midiMessages.begin());
+        }
+        lock.unlock();
+    }
+
+    void refreshDevices() {
+        ofLogNotice("ofxMidiIn") << midiIn.getNumInPorts() << " ports available";
+        midiDevices.clear();
+        midiDevices = midiIn.getInPortList();
+        midiDevices.insert(midiDevices.begin(), "none");
+    }
+
+    void doGui()
+    {
+
+    }
+
+    ofxMidiIn midiIn;
+    std::vector<ofxMidiMessage> midiMessages;
+    std::vector<string> midiDevices;
+    int currentDevice = 0;
+    std::size_t maxMessages = 100; //< max number of messages to keep track of
+    ofMutex lock;
+    bool verbose = false;
+    bool ignoreSysex= false;
+    bool ignoreTiming = false;
+    bool ignoreSense = false;
+};
+
+#endif // MIDINODE_H

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -6,6 +6,7 @@
 #include "ofxXmlSettings.h"
 #include "client.h"
 #include "ofxImGui.h"
+#include "imgui_stdlib.h"
 #include "uiWidgets.h"
 #include "ofpy.h"
 #include "midinode.h"
@@ -47,7 +48,8 @@ public:
     
     void setupConnectionInterface();
     void setupData(string filename);
-    void addClient(int i,string ip,int p,string n,bool r,bool m,bool s,bool live, bool hierarchy, int modeFlags);
+    void setupOSCReceiver();
+    void addClient(int i,string ip,int p,string n,bool r,bool m,bool s,bool live, bool hierarchy, int modeFlags, bool midi, bool osc);
     void sendOSC();
     void sendMidi();
 
@@ -59,6 +61,10 @@ public:
     void setFeedback(string feedbackText);
 
     midiNode midiIn;
+
+    // OSC Receiver
+    ofxOscReceiver oscRecv;
+    int oscListenPort = 2525;
 
     //GUI
     ofxImGui::Gui gui;

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -8,6 +8,7 @@
 #include "ofxImGui.h"
 #include "uiWidgets.h"
 #include "ofpy.h"
+#include "midinode.h"
 
 //for velocity, defines how many layers to apply (2 * layers + 1 frames)
 #define SMOOTHING 0
@@ -48,14 +49,17 @@ public:
     void setupData(string filename);
     void addClient(int i,string ip,int p,string n,bool r,bool m,bool s,bool live, bool hierarchy, int modeFlags);
     void sendOSC();
-    
+    void sendMidi();
+
     bool connectNatnet(string interfaceName, string interfaceIP);
     
     void saveData(string filepath);
     void deleteClient(int &index);
     
     void setFeedback(string feedbackText);
-    
+
+    midiNode midiIn;
+
     //GUI
     ofxImGui::Gui gui;
     bool guiVisible;
@@ -67,6 +71,7 @@ public:
     uiLogger uiLogWidget;
     
 private:
+
     void                    sendAllMarkers();
     void                    sendAllRigidBodys();
     void                    sendAllSkeletons();

--- a/src/themes.cpp
+++ b/src/themes.cpp
@@ -39,9 +39,6 @@ void GuiBlueTheme::setup()
         style.Colors[ImGuiCol_Header] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 0.76f );
         style.Colors[ImGuiCol_HeaderHovered] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 0.86f );
         style.Colors[ImGuiCol_HeaderActive] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 1.00f );
-        style.Colors[ImGuiCol_Column] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 0.32f );
-        style.Colors[ImGuiCol_ColumnHovered] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 0.78f );
-        style.Colors[ImGuiCol_ColumnActive] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 1.00f );
         style.Colors[ImGuiCol_ResizeGrip] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 0.15f );
         style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 0.78f );
         style.Colors[ImGuiCol_ResizeGripActive] = ImVec4( color_for_head.x, color_for_head.y, color_for_head.z, 1.00f );
@@ -146,9 +143,6 @@ void GuiGreenTheme::setup()
     style.Colors[ImGuiCol_Header]                = MED( 0.76f);
     style.Colors[ImGuiCol_HeaderHovered]         = MED( 0.86f);
     style.Colors[ImGuiCol_HeaderActive]          = HI( 1.00f);
-    style.Colors[ImGuiCol_Column]                = ImVec4(0.14f, 0.16f, 0.19f, 1.00f);
-    style.Colors[ImGuiCol_ColumnHovered]         = MED( 0.78f);
-    style.Colors[ImGuiCol_ColumnActive]          = MED( 1.00f);
     style.Colors[ImGuiCol_ResizeGrip]            = ImVec4(0.47f, 0.77f, 0.83f, 0.04f);
     style.Colors[ImGuiCol_ResizeGripHovered]     = MED( 0.78f);
     style.Colors[ImGuiCol_ResizeGripActive]      = MED( 1.00f);
@@ -202,9 +196,6 @@ void GuiCherryTheme::setup() {
     style.Colors[ImGuiCol_Header]                = MED2( 0.76f);
     style.Colors[ImGuiCol_HeaderHovered]         = MED2( 0.86f);
     style.Colors[ImGuiCol_HeaderActive]          = HI2( 1.00f);
-    style.Colors[ImGuiCol_Column]                = ImVec4(0.14f, 0.16f, 0.19f, 1.00f);
-    style.Colors[ImGuiCol_ColumnHovered]         = MED2( 0.78f);
-    style.Colors[ImGuiCol_ColumnActive]          = MED2( 1.00f);
     style.Colors[ImGuiCol_ResizeGrip]            = ImVec4(0.47f, 0.77f, 0.83f, 0.04f);
     style.Colors[ImGuiCol_ResizeGripHovered]     = MED2( 0.78f);
     style.Colors[ImGuiCol_ResizeGripActive]      = MED2( 1.00f);


### PR DESCRIPTION
This change adds Midi support to the bridge. Through this you can receive MIDI events which are then translated to OSC.

We also added OSC receive support as a convenience. You can now listen on a port, anything received on the port can be sent to clients. 