### PR TITLE
windows errors on c++17 for loop, revert to oldschool loop

### DIFF
--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -41,9 +41,11 @@ void ofApp::setup()
 
     //fill the interface list
     auto niclist = listNetworkInterfaces( ANY, NetworkInterface::IPv4_ONLY );
-    for (const auto& interface: niclist )
+    auto itr =  niclist.begin();
+    while ( itr != niclist.end() )
     {
-        iface_list.push_back( interface.name() );
+        iface_list.push_back( itr->name() );
+        *itr++;
     }
     // and set the current iface to last found (first is probably lo)
     current_iface_idx = iface_list.size() - 1;


### PR DESCRIPTION
To fix windows issues [ofxNatNet](https://github.com/hku-ect/ofxNatNet/pull/8) and [ofxImGui](https://github.com/sphaero/ofxImGui/pull/2) needed fixing as well